### PR TITLE
Restrict deployment to HTTPS port 8443

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,9 @@ RUN a2enmod rewrite ssl && \
       -out /etc/ssl/certs/selfsigned.crt \
       -subj "/CN=localhost" && \
     sed -i 's#/etc/ssl/certs/ssl-cert-snakeoil.pem#/etc/ssl/certs/selfsigned.crt#' /etc/apache2/sites-available/default-ssl.conf && \
-    sed -i 's#/etc/ssl/private/ssl-cert-snakeoil.key#/etc/ssl/private/selfsigned.key#' /etc/apache2/sites-available/default-ssl.conf
+    sed -i 's#/etc/ssl/private/ssl-cert-snakeoil.key#/etc/ssl/private/selfsigned.key#' /etc/apache2/sites-available/default-ssl.conf && \
+    a2dissite 000-default && \
+    sed -i 's/^Listen 80/#Listen 80/' /etc/apache2/ports.conf
 
 # Instalar as dependências do Composer (se houver um composer.json)
 WORKDIR /var/www/html
@@ -40,4 +42,4 @@ RUN if [ -f "composer.json" ]; then composer install --no-interaction; fi
 # Define o diretório de trabalho padrão
 WORKDIR /var/www/html
 
-EXPOSE 80 443
+EXPOSE 443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     build: .
     image: web:latest
     ports:
-      - "8080:80"
       - "8443:443"
     depends_on:
       - gateway
@@ -15,8 +14,6 @@ services:
       context: .
       dockerfile: services/gateway/Dockerfile
     image: gateway:latest
-    ports:
-      - "8081:80"
     depends_on:
       - tickets
       - stats
@@ -45,8 +42,6 @@ services:
       MYSQL_DATABASE: chamaweb
       MYSQL_USER: user
       MYSQL_PASSWORD: userpass
-    ports:
-      - "3306:3306"
     volumes:
       - db_data:/var/lib/mysql
       - ./script_sql.sql:/docker-entrypoint-initdb.d/init.sql:ro
@@ -54,8 +49,6 @@ services:
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
     restart: always
-    ports:
-      - "8082:80"
     environment:
       PMA_HOST: db
       MYSQL_ROOT_PASSWORD: root

--- a/inc/CognitoAuth.php
+++ b/inc/CognitoAuth.php
@@ -93,7 +93,7 @@ class CognitoAuth {
      */
     public function getLogoutUrl($redirectUri = null) {
         if (!$redirectUri) {
-            $redirectUri = 'http://localhost:8080/index.php';
+            $redirectUri = 'https://localhost:8443/index.php';
         }
         
         // Construir a URL de logout corretamente

--- a/inc/cognito_config.php
+++ b/inc/cognito_config.php
@@ -6,7 +6,7 @@ return [
         'user_pool_id' => 'us-east-2_nGsr1zSvz',
         'client_id' => '5drp597e5uk101sbcsqqcgsmmn',
         'client_secret' => 'l0c2bbuk3l63h0u2d25cec4is0a05koj791bu5k2gfesrc8ntre',
-        'redirect_uri' => 'http://localhost:8080/auth_callback.php',
+        'redirect_uri' => 'https://localhost:8443/auth_callback.php',
         'scope' => 'email openid phone',
         
         // Domínio completo do Cognito (sem https://)

--- a/logout.php
+++ b/logout.php
@@ -15,7 +15,7 @@ session_destroy();
 if ($wasCognitoAuth) {
     $domain = 'us-east-2ngsr1zsvz.auth.us-east-2.amazoncognito.com';
     $clientId = '5drp597e5uk101sbcsqqcgsmmn';
-    $logoutUri = 'http://localhost:8080/index.php';
+    $logoutUri = 'https://localhost:8443/index.php';
     $logoutUrl = 'https://' . $domain . '/logout?client_id=' . $clientId . '&logout_uri=' . urlencode($logoutUri);
     header('Location: ' . $logoutUrl);
     exit;


### PR DESCRIPTION
## Summary
- disable Apache HTTP bindings and expose only HTTPS inside the web container
- remove host port publications for supporting services so the host only exposes 8443
- update documentation and Cognito/logout redirects to reference the new HTTPS endpoint

## Testing
- `php -l logout.php`
- `php -l inc/cognito_config.php`
- `php -l inc/CognitoAuth.php`


------
https://chatgpt.com/codex/tasks/task_e_68c9f9f8aa188327acb55d40d875d315